### PR TITLE
fix: correct priority ordering for urgent vs important todos

### DIFF
--- a/docker-data/test.json
+++ b/docker-data/test.json
@@ -1,1 +1,26 @@
-success
+[
+  {
+    "text": "Urgent only todo",
+    "priorities": ["urgent"],
+    "order_index": 1,
+    "created_at": 1685037654
+  },
+  {
+    "text": "Important only todo", 
+    "priorities": ["important"],
+    "order_index": 2,
+    "created_at": 1685037654
+  },
+  {
+    "text": "Urgent and important todo",
+    "priorities": ["urgent", "important"],
+    "order_index": 3,
+    "created_at": 1685037654
+  },
+  {
+    "text": "No priority todo",
+    "priorities": [],
+    "order_index": 4,
+    "created_at": 1685037654
+  }
+]

--- a/docker/init.lua
+++ b/docker/init.lua
@@ -269,27 +269,27 @@ require("doit").setup({
 
 	priorities = {
 		{
-			name = "important",
-			weight = 4,
+			name = "urgent",
+			weight = 8,
 		},
 		{
-			name = "urgent",
-			weight = 2,
+			name = "important",
+			weight = 4,
 		},
 	},
 	priority_groups = {
 		high = {
-			members = { "important", "urgent" },
+			members = { "urgent", "important" },
 			color = nil,
 			hl_group = "DiagnosticError",
 		},
 		medium = {
-			members = { "important" },
+			members = { "urgent" },
 			color = nil,
 			hl_group = "DiagnosticWarn",
 		},
 		low = {
-			members = { "urgent" },
+			members = { "important" },
 			color = nil,
 			hl_group = "DiagnosticInfo",
 		},

--- a/lua/doit/config.lua
+++ b/lua/doit/config.lua
@@ -37,27 +37,27 @@ M.defaults = {
 	},
 	priorities = {
 		{
-			name = "important",
-			weight = 4,
+			name = "urgent",
+			weight = 8,
 		},
 		{
-			name = "urgent",
-			weight = 2,
+			name = "important", 
+			weight = 4,
 		},
 	},
 	priority_groups = {
 		high = {
-			members = { "important", "urgent" },
+			members = { "urgent", "important" },
 			color = nil,
 			hl_group = "DiagnosticError",
 		},
 		medium = {
-			members = { "important" },
+			members = { "urgent" },
 			color = nil,
 			hl_group = "DiagnosticWarn",
 		},
 		low = {
-			members = { "urgent" },
+			members = { "important" },
 			color = nil,
 			hl_group = "DiagnosticInfo",
 		},

--- a/lua/doit/state/sorting.lua
+++ b/lua/doit/state/sorting.lua
@@ -26,22 +26,22 @@ function Sorting.setup(M, config)
 				end
 			end
 
-			-- 2) Sort by order_index if both have it
+			-- 2) Sort by priority score for non-done items
+			if not a.done and not b.done and config.options.priorities and #config.options.priorities > 0 then
+				local a_score = M.get_priority_score(a) -- from priorities.lua
+				local b_score = M.get_priority_score(b)
+				if a_score ~= b_score then
+					return a_score > b_score
+				end
+			end
+
+			-- 3) Sort by order_index if both have it (for manual ordering)
 			if a.order_index and b.order_index then
 				return a.order_index < b.order_index
 			elseif a.order_index then
 				return true
 			elseif b.order_index then
 				return false
-			end
-
-			-- 3) Sort by priority score
-			if config.options.priorities and #config.options.priorities > 0 then
-				local a_score = M.get_priority_score(a) -- from priorities.lua
-				local b_score = M.get_priority_score(b)
-				if a_score ~= b_score then
-					return a_score > b_score
-				end
 			end
 
 			-- 4) Sort by due date

--- a/tests/state/priority_order_spec.lua
+++ b/tests/state/priority_order_spec.lua
@@ -1,0 +1,141 @@
+local doit_state = require("doit.state")
+local priorities = require("doit.state.priorities")
+local config = require("doit.config")
+
+describe("priority ordering", function()
+    before_each(function()
+        -- Reset state
+        doit_state.todos = {}
+        
+        -- Set up the config with our test priorities
+        config.options = {
+            priorities = {
+                {
+                    name = "urgent",
+                    weight = 8,
+                },
+                {
+                    name = "important",
+                    weight = 4,
+                },
+            },
+        }
+
+        -- Initialize priority weights
+        doit_state.update_priority_weights()
+    end)
+
+    it("should sort urgent items before important ones", function()
+        doit_state.todos = {
+            { 
+                text = "Important only", 
+                done = false, 
+                created_at = os.time(), 
+                priorities = { "important" } 
+            },
+            { 
+                text = "Urgent only", 
+                done = false, 
+                created_at = os.time(), 
+                priorities = { "urgent" } 
+            },
+            { 
+                text = "Both urgent and important", 
+                done = false, 
+                created_at = os.time(), 
+                priorities = { "urgent", "important" } 
+            },
+            { 
+                text = "No priority", 
+                done = false, 
+                created_at = os.time(), 
+                priorities = {} 
+            },
+        }
+
+        doit_state.sort_todos()
+
+        assert.are.equal("Both urgent and important", doit_state.todos[1].text)
+        assert.are.equal("Urgent only", doit_state.todos[2].text)
+        assert.are.equal("Important only", doit_state.todos[3].text)
+        assert.are.equal("No priority", doit_state.todos[4].text)
+    end)
+
+    it("should prioritize in-progress items at the top, then sorted by priority", function()
+        doit_state.todos = {
+            { 
+                text = "Important only", 
+                done = false, 
+                created_at = os.time(), 
+                priorities = { "important" } 
+            },
+            { 
+                text = "Urgent only (in progress)", 
+                done = false, 
+                in_progress = true,
+                created_at = os.time(), 
+                priorities = { "urgent" } 
+            },
+            { 
+                text = "Important only (in progress)", 
+                done = false, 
+                in_progress = true,
+                created_at = os.time(), 
+                priorities = { "important" } 
+            },
+            { 
+                text = "Urgent only", 
+                done = false, 
+                created_at = os.time(), 
+                priorities = { "urgent" } 
+            },
+        }
+
+        doit_state.sort_todos()
+
+        assert.are.equal("Urgent only (in progress)", doit_state.todos[1].text)
+        assert.are.equal("Important only (in progress)", doit_state.todos[2].text)
+        assert.are.equal("Urgent only", doit_state.todos[3].text)
+        assert.are.equal("Important only", doit_state.todos[4].text)
+    end)
+
+    it("should prioritize by weight even with order_index", function()
+        doit_state.todos = {
+            { 
+                text = "Important only", 
+                done = false, 
+                created_at = os.time(), 
+                priorities = { "important" },
+                order_index = 1
+            },
+            { 
+                text = "Urgent only", 
+                done = false, 
+                created_at = os.time(), 
+                priorities = { "urgent" },
+                order_index = 2
+            },
+            { 
+                text = "Both urgent and important", 
+                done = false, 
+                created_at = os.time(), 
+                priorities = { "urgent", "important" },
+                order_index = 3
+            },
+            { 
+                text = "No priority", 
+                done = false, 
+                created_at = os.time(), 
+                priorities = {},
+                order_index = 4
+            },
+        }
+
+        doit_state.sort_todos()
+
+        assert.are.equal("Both urgent and important", doit_state.todos[1].text)
+        assert.are.equal("Urgent only", doit_state.todos[2].text)
+        assert.are.equal("Important only", doit_state.todos[3].text)
+        assert.are.equal("No priority", doit_state.todos[4].text)
+    end)
+end)


### PR DESCRIPTION
- Fix order of priorities in config with urgent (weight 8) before important (weight 4)
- Modify sorting logic to prioritize by priority score before order_index
- Add test case to verify urgent todos now appear before important ones
- Maintain in-progress/active todos at the top of the list